### PR TITLE
Feat: Integration testing workflow

### DIFF
--- a/.github/composite/melos-bootstrap/action.yaml
+++ b/.github/composite/melos-bootstrap/action.yaml
@@ -1,0 +1,24 @@
+name: melos bootstrap
+description: Installs flutter & melos, then runs melos bootstrap
+
+inputs:
+  build_id:
+    required: false
+    description: Optional build key to use as a cache key for flutter
+
+runs:
+  using: composite
+  steps:
+    - uses: subosito/flutter-action@v2
+      with:
+        channel: 'stable'
+        cache: ${{ inputs.build_id != "" }}
+        cache-key: ${{ inputs.build_id }}
+    
+    - name: Install melos
+      run: dart pub global activate melos
+      shell: bash
+
+    - name: Bootstrap project with melos
+      run: dart pub global run melos bootstrap
+      shell: bash

--- a/.github/composite/update-submodule/action.yaml
+++ b/.github/composite/update-submodule/action.yaml
@@ -1,0 +1,17 @@
+name: Update submodule
+description: Update a submodule in this repository
+
+inputs:
+  module:
+    required: true
+    description: The name of the module in modules/
+
+runs:
+  using: composite
+  steps:
+    - name: Update module
+      shell: bash
+      env:
+        MODULE: ${{ inputs.module }}
+      run: |
+        git submodule update --init --remote --reference "https://github.com/atsign-foundation/$MODULE.git" -- "modules/$MODULE";

--- a/.github/composite/update-submodules/action.yaml
+++ b/.github/composite/update-submodules/action.yaml
@@ -1,0 +1,22 @@
+name: Update submodules
+description: Update all submodules in this repository
+
+runs:
+  using: composite
+  steps:
+    - name: Update modules
+      shell: bash
+      env:
+        MODULE: ${{ inputs.module }}
+      # Update each in parallel
+      # Then wait on each process id to ensure all updates are completed before moving on
+      run: |
+        source ./tools/REPOS.sh
+        for i in ${REPOS//,/ }; do
+          git submodule update --init --remote --reference "https://github.com/atsign-foundation/$i.git" -- "modules/$i" &
+          pids[${i}]=$!
+        done;
+
+        for pid in ${pids[*]}; do
+          wait $pid
+        done;

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,0 +1,58 @@
+name: Integration Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        required: false
+        description: The single module to update (by default all will be updated)
+
+env:
+  REPO: atsign-foundation/at_mono
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    outputs:
+      commit_ref: ${{ steps.commit_id.outputs.changes_detected && steps.commit_id.outputs.commit_hash || github.sha }}
+      build_id: ${{ format("{0}-{1}", github.run_id, github.run_attempt) }}
+
+    if: ${{ github.repository != env.REPO }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update all modules
+        if: ${{ github.event.inputs.module == "" }}
+        uses: ./.github/composite/update-submodules
+
+      - name: Update single module
+        if: ${{ github.event.inputs.module != "" }}
+        uses: ./.github/composite/update-submodule
+        with:
+          module: ${{ github.event.inputs.module }}
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        id: commit_id
+        with:
+          commit_message: Update submodules
+          create_branch: false
+          branch: trunk
+
+      - run: echo ${{ steps.commit_id.outputs.commit_hash }}
+
+  at_server_tests:
+    needs: build
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.build.outputs.commit_ref }}
+
+      - uses: ./.github/composite/melos-bootstrap
+        with:
+          build_id: ${{ needs.build.outputs.build_id }}
+
+      - name: "TODO: IMPLEMENT TESTS"
+        run: echo "IMPLEMENT TESTS"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Created the following actions:

composite actions:
- update-submodule & update-submodules
  To update a single or all submodules respectively
- melos-bootstrap
  Installs flutter, then melos, then runs melos bootstrap (which links all packages locally)
  Opted for flutter sdk only, so we can use caching to parallelize tests

workflows:
- Integration tests
  - build job
    - Takes an optional module arg (name of the module to update)
      Updates the single module if specified, or all if not specified
    - Commits & pushes the updated module references
    - Runs melos-bootstrap workflow
    - Caches Flutter SDK
    - Caches all pubspec.lock files (so we don't have to melos bootstrap again)
  - at_server_test
    - Retrieves both caches, does nothing else yet

**- How I did it**

Local changes

**- How to verify it**

See [my test run](https://github.com/XavierChanth/at_mono/actions/runs/2512366728)

**- Description for the changelog**
Feat: Integration testing workflow
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->