### PR TITLE
docs: Added some diagrams for the "Securely share data between AtSigns" code path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # at_mono
 
-<img width=250px src="https://atsign.dev/assets/img/atPlatform_logo_gray.svg?sanitize=true">
+<img width=250px src="https://atsign.dev/assets/img/atPlatform_logo_gray.svg?sanitize=true" alt="AtPlatform Logo, gray, svg">
 
 [![GitHub License](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
 
-This is a poly-as-mono repo used for integration testing of our dart and flutter
-packages.
+This is a poly-as-mono repo which we created for integration testing of our dart and
+flutter packages.
 
 ## Why create something like this?
 
 There are benefits to both poly and mono repo approaches. In this organization,
 we've opted to go with a poly repo which suits most of our development needs.
-One of the main reasons to opt for a mono repo is for integration testing. Hence
-why we've created a poly-as-mono repo to make integration testing easier.
+One of the main reasons to opt for a mono repo is for integration testing, and
+therefore we've created a poly-as-mono repo to make integration testing easier.
+It is also a useful place in which to keep diagrams of end-to-end user journeys,
+code paths etc. which almost always span multiple individual repos.
 
 ## Poly repos included
 

--- a/diagrams/e2e_code_paths.md
+++ b/diagrams/e2e_code_paths.md
@@ -1,0 +1,14 @@
+# Primary end-to-end flows
+A place to list the most-used / most important end-to-end features and the code paths & data flows
+which implement those features.
+
+## Core data sharing
+* End-to-end encrypted data sharing between AtSigns
+* Share (e.g. across devices) data which is encrypted for the current AtSign only
+* Share data publicly
+
+## AtSign registration / activation / onboarding
+* IOT device provisioning / activation / onboarding - 
+See [here](https://github.com/atsign-company/gary-snippets/blob/main/diagrams/iot_provisioning-integration.md) for now
+
+## AtSign deletion / reset

--- a/diagrams/e2e_code_paths.md
+++ b/diagrams/e2e_code_paths.md
@@ -3,7 +3,7 @@ A place to list the most-used / most important end-to-end features and the code 
 which implement those features.
 
 ## Core data sharing
-* End-to-end encrypted data sharing between AtSigns
+* [End-to-end encrypted data sharing between AtSigns](https://github.com/atsign-foundation/at_mono/blob/gkc_diagrams/diagrams/e2ee_share_alice_bob.md)
 * Share (e.g. across devices) data which is encrypted for the current AtSign only
 * Share data publicly
 

--- a/diagrams/e2ee_share_alice_bob.md
+++ b/diagrams/e2ee_share_alice_bob.md
@@ -1,0 +1,115 @@
+# End-to-end encrypted data sharing between AtSigns
+
+## @alice sharing data with @bob, encrypted so that only @bob can decrypt (aka end-to-end-encrypted or e2ee)
+```mermaid
+sequenceDiagram
+    participant @alice
+    participant @bob
+
+    note over @alice, @bob : If @alice has not already created a shared secret for @alice-to-@bob ...
+    @alice ->> @bob : Get the public key from @bob's asymmetric encryption keypair
+    @bob ->> @alice : [@bob's public key]
+    @alice ->> @alice : Create symmetric encryption key <br/> [@alice-to-@bob-shared-secret]
+    @alice ->> @alice : Encrypt [@alice-to-@bob-shared-secret] <br/> with @bob's public key
+    @alice ->> @bob : Send [@alice-to-@bob-shared-secret] <br/> decryptable only by @bob's private key
+    @bob ->> @bob : Decrypt [@alice-to-@bob-shared-secret] <br/> using [@bob's asymmetric encryption private key]
+
+    note over @alice, @bob : @alice and @bob now have a <br/> shared secret for encryption/decryption
+
+    @alice ->> @alice : Encrypt 'Hello, Bob!' using <br/>[@alice-to-@bob-shared-secret]
+    @alice ->> @bob : [ciphertext] 
+    @bob ->> @bob : Decrypt [ciphertext] using <br/>[@alice-to-@bob-shared-secret]
+    note over @bob : Hello, Bob!
+```
+
+## More detailed code paths / data flow
+Note: This is still simplified, just points you to the code implementation
+
+**TODO**: Add all of the GitHub hyperlinks
+**TODO**: Find a way to keep hyperlinks reasonably up to date given there will be code drift over time
+
+```mermaid
+flowchart TB
+    subgraph AliceClient
+        A[Client code]-->ATCIP
+
+        subgraph ATC[AtClientImpl]
+            style ATC fill:#39f
+            direction TB
+            ATCIP["AtClientImpl.put('@bob:12345.messages.bob.chats.myapp.example.com@alice', 'Hello, @bob!')"]
+            click ATCIP "https://github.com/atsign-foundation/at_client_sdk/blob/trunk/at_client/lib/src/client/at_client_impl.dart" "View AtClientImpl.put on GitHub"
+            subgraph PRT["PutRequestTransformer"]
+                style PRT fill:#cbc
+                PRT.transform["transform ('@bob:12345.messages.bob.chats.myapp.example.com@alice', 'Hello, @bob!')"]
+                click PRT.transform "https://github.com/atsign-foundation/at_client_sdk/blob/trunk/at_client/lib/src/transformer/request_transformer/put_request_transformer.dart" "View PutRequestTransformer.transform on GitHub"
+                subgraph SKE["SharedKeyEncryption"]
+                    style SKE fill:#bcc
+                    SKE.encrypt["SharedKeyEncryption.encrypt('@bob:12345.messages.bob.chats.myapp.example.com@alice', 'Hello, @bob!')"]
+                    subgraph AKE["AbstractAtKeyEncryption"]
+                        style AKE fill:#ccb
+                        AKE.encrypt["AbstractAtKeyEncryption.encrypt('@bob:12345.messages.bob.chats.myapp.example.com@alice', 'Hello, @bob!')"]
+                        AKE.getSharedKey["AbstractAtKeyEncryption.getSharedKey('@bob:12345.messages.bob.chats.myapp.example.com@alice')"]
+                        AKE.gcsk["_getCachedSharedKey : look up 'shared_key.bob@alice' in local datastore"]
+                        AKE.fcsk
+                        AKE.rlsk["_getSharedKeyFromRemote : <br/>call 'llookup:shared_key.bob@alice' on remote secondary"]
+                        AKE.frsk
+                        subgraph AKE.csk["_createSharedKey"]
+                            direction TB
+                            GetBobsPublicKey-->CreateAESKey
+                            CreateAESKey["CreateAESKey @alice-to-@bob-shared-secret"]
+                            CreateAESKey-->EncryptWithBobsPublicKey
+                            EncryptWithBobsPublicKey-->update["send to @bob"]
+                            CreateAESKey-->EncryptWithAlicesPublicKey
+                            EncryptWithAlicesPublicKey-->save["store for @alice to reuse later"]
+                        end
+                    end
+                    SKE.encryptValue["SharedKeyEncryption.encryptValue('Hello, Bob!', @alice-to-@bob-shared-secret)"]
+                end
+            end
+            subgraph Secondary
+                style Secondary fill:#aba
+                Secondary.executeVerb
+                Secondary.DoTheUpdate["Either <br/>(1) Do the local update and wait for sync if using local secondary <br/>or<br/>(2) marshall the update: command and send to remote secondary.<br/><br/>In either event, we end up sending an update command to @alice's secondary server"]
+            end
+        end
+    end
+    subgraph CSS_a["@alice Cloud Secondary Server"]
+        style CSS_a fill:#f80
+        CSS_a.UpdateVerbHandler-->CSS_a.Store
+        CSS_a.Store-->CSS_a.NotifyBobSecondary
+        CSS_a.NotifyBobSecondary-->PrepareNotifyCommand
+        PrepareNotifyCommand-->ConnectToBobSecondary
+        ConnectToBobSecondary-->CSS_a.SendNotifyCommandToBob
+    end
+    CSS_a.SendNotifyCommandToBob-->CSS_b
+    subgraph CSS_b["@bob Cloud Secondary Server"]
+        style CSS_b fill:#08f
+        CSS_b.NotifyVerbHandler["NotifyVerbHandler"]
+        CSS_b.NotifyVerbHandler-->CSS_b.Store["Store to dataStore"]
+        CSS_b.NotifyAnyConnectedClients["Notify any connected @bob clients"] 
+        CSS_b.Store-->CSS_b.NotifyAnyConnectedClients
+        CSS_b.NotifyAnyConnectedClients-->BobMonitor
+    end
+    
+    subgraph BobClient
+        BobMonitor
+        BobMonitor-->BobClientTODO
+        BobClientTODO["TODO: Still need to flesh out what happens on @bob client side"]
+    end
+    
+    ATCIP-->PRT.transform
+    PRT.transform-->SKE.encrypt
+    SKE.encrypt-->AKE.encrypt
+    AKE.encrypt-->AKE.getSharedKey
+    AKE.getSharedKey-->AKE.gcsk
+    AKE.gcsk-->AKE.fcsk{Found in Local Datastore?}
+        AKE.fcsk-->|Yes| SKE.encryptValue
+        AKE.fcsk-->|No| AKE.rlsk
+            AKE.rlsk-->AKE.frsk{Found in remote Secondary?}
+                AKE.frsk-->|Yes| SKE.encryptValue
+                AKE.frsk-->|No| AKE.csk
+            AKE.csk---->SKE.encryptValue
+    SKE.encryptValue-->Secondary.executeVerb
+    Secondary.executeVerb-->Secondary.DoTheUpdate
+    Secondary.DoTheUpdate-->CSS_a.UpdateVerbHandler
+```

--- a/diagrams/e2ee_share_alice_bob.md
+++ b/diagrams/e2ee_share_alice_bob.md
@@ -1,6 +1,7 @@
 # End-to-end encrypted data sharing between AtSigns
 
-## @alice sharing data with @bob, encrypted so that only @bob can decrypt (aka end-to-end-encrypted or e2ee)
+## Simple logical sequence diagram
+@alice sharing data with @bob, encrypted so that only @bob can decrypt (aka end-to-end-encrypted or e2ee)
 ```mermaid
 sequenceDiagram
     participant @alice
@@ -23,9 +24,9 @@ sequenceDiagram
 ```
 
 ## More detailed code paths / data flow
-Note: This is still simplified, just points you to the code implementation
+Note: This is still a bit simplified, but does enumerate the critical pieces of the code path and data flow
 
-**TODO**: Add all of the GitHub hyperlinks
+**TODO**: Add more hyperlinks to the code on GitHub
 **TODO**: Find a way to keep hyperlinks reasonably up to date given there will be code drift over time
 
 ```mermaid

--- a/diagrams/e2ee_share_alice_bob.md
+++ b/diagrams/e2ee_share_alice_bob.md
@@ -76,27 +76,27 @@ flowchart TB
     end
     subgraph CSS_a["@alice Cloud Secondary Server"]
         style CSS_a fill:#f80
-        CSS_a.UpdateVerbHandler-->CSS_a.Store
-        CSS_a.Store-->CSS_a.NotifyBobSecondary
+        CSS_a.UpdateVerbHandler-->CSS_a.Store["Store to dataStore"]
+        CSS_a.Store-->CSS_a.NotifyBobSecondary["NotifyBobSecondary"]
         CSS_a.NotifyBobSecondary-->PrepareNotifyCommand
         PrepareNotifyCommand-->ConnectToBobSecondary
-        ConnectToBobSecondary-->CSS_a.SendNotifyCommandToBob
+        ConnectToBobSecondary-->CSS_a.SendNotifyCommandToBobSecondaryServer
     end
-    CSS_a.SendNotifyCommandToBob-->CSS_b
+    CSS_a.SendNotifyCommandToBobSecondaryServer-->CSS_b
     subgraph CSS_b["@bob Cloud Secondary Server"]
         style CSS_b fill:#08f
         CSS_b.NotifyVerbHandler["NotifyVerbHandler"]
         CSS_b.NotifyVerbHandler-->CSS_b.Store["Store to dataStore"]
         CSS_b.NotifyAnyConnectedClients["Notify any connected @bob clients"] 
         CSS_b.Store-->CSS_b.NotifyAnyConnectedClients
-        CSS_b.NotifyAnyConnectedClients-->BobMonitor
     end
     
     subgraph BobClient
         BobMonitor
         BobMonitor-->BobClientTODO
-        BobClientTODO["TODO: Still need to flesh out what happens on @bob client side"]
+        BobClientTODO["TODO: Finish this off. Add the full remaining info about what happens on @bob client side"]
     end
+    CSS_b.NotifyAnyConnectedClients-->BobMonitor
     
     ATCIP-->PRT.transform
     PRT.transform-->SKE.encrypt

--- a/diagrams/e2ee_share_alice_bob.md
+++ b/diagrams/e2ee_share_alice_bob.md
@@ -56,6 +56,7 @@ flowchart TB
                         AKE.frsk
                         subgraph AKE.csk["_createSharedKey"]
                             direction TB
+                            GetBobsPublicKey["Get Bob's public key. <br/>This involves sending a plookup command <br/> to @alice's secondary which then does a <br/>lookup on @bob secondary"]
                             GetBobsPublicKey-->CreateAESKey
                             CreateAESKey["CreateAESKey @alice-to-@bob-shared-secret"]
                             CreateAESKey-->EncryptWithBobsPublicKey


### PR DESCRIPTION
Added some diagrams for arguably the AtPlatform's primary e2e use case / code path, "Securely share data between AtSigns"

We will move this again soon, to atsign.dev

**- What I did**
Added some diagrams

**- How I did it**
Used mermaid markdown for the diagrams themselves

**- How to verify it**
Please take a look. Quickest way to see the rendered diagrams is to look at them via [the branch ](https://github.com/atsign-foundation/at_mono/blob/gkc_diagrams/diagrams/e2ee_share_alice_bob.md)

**- Description for the changelog**
Added some diagrams for the "Securely share data between AtSigns" code path