### PR TITLE
fix: Use PAT for commits

### DIFF
--- a/.github/composite/build/action.yaml
+++ b/.github/composite/build/action.yaml
@@ -31,6 +31,7 @@ runs:
       uses: stefanzweifel/git-auto-commit-action@v4
       id: commit_id
       with:
+        token: ${{ secrets.MY_GITHUB_TOKEN }}
         commit_message: 'chore: Update submodules'
         create_branch: false
         branch: trunk


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Used a token for git auto commit which should have permissions to push to protected branches.
  The default GitHub token does not have privileges to push to protected branches.

**- How I did it**

Added the organization PAT as the token in the build action.

**- How to verify it**

Run dailyBackup after merging.

**- Description for the changelog**
fix: Use PAT for commits
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->