### PR TITLE
fix: allow non-trunk branches to commit to themselves

### DIFF
--- a/.github/composite/build/action.yaml
+++ b/.github/composite/build/action.yaml
@@ -26,14 +26,12 @@ runs:
       uses: ./.github/composite/update-submodule
       with:
         module: ${{ inputs.module }}
-    
+
     - name: Auto commit submodules update
       uses: stefanzweifel/git-auto-commit-action@v4
       id: commit_id
       with:
         commit_message: 'chore: Update submodules'
-        create_branch: false
-        branch: trunk
 
     - name: Echo commit hash (if any) && Set build id
       shell: bash


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Removed the line from the workflow that was causing non-trunk branches to perform the build to be committed on trunk.

**- How I did it**

Local changes.

**- How to verify it**

**- Description for the changelog**
fix: allow non-trunk branches to commit to themselves
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->