### PR TITLE
fix: remove trailing wildcard from package paths (melos 3.0)

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -1,14 +1,14 @@
 name: at_mono
 
 packages:
-  - modules/*/packages/*/*
+  - modules/*/packages/*
   # at_libraries
-  - modules/at_libraries/at_*/*
-  - modules/at_libraries/base2e15/*
-  - modules/at_libraries/dart_utf7/*
-  - modules/at_libraries/redis-dart/*
+  - modules/at_libraries/at_*
+  - modules/at_libraries/base2e15
+  - modules/at_libraries/dart_utf7
+  - modules/at_libraries/redis-dart
   # at_tools
-  - modules/at_tools/at_*/*
+  - modules/at_tools/at_*
 
 scripts:
   update: |


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Removed the trailing wildcard in the package path globs because melos 3.0 went from expecting the path to the pubspec.yaml to expecting the directory of a package (i.e. a directory containing a pubspec.yaml).

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: remove trailing wildcard from package paths (melos 3.0)
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->